### PR TITLE
[bugfix]: subDirLinks iterate bugfix

### DIFF
--- a/src/js/popup.js
+++ b/src/js/popup.js
@@ -243,7 +243,8 @@ async function fetchRandomVideo() {
       : videoSourceUrl;
     const subDirLinks = Array.from(doc.querySelectorAll("a"))
       .map((a) => new URL(a.getAttribute("href"), baseHref).href)
-      .filter((href) => href.endsWith("/"));
+      .filter((href) => href.endsWith("/") && href != (new URL('/',baseHref)).href
+      );
 
     for (const dirLink of subDirLinks) {
       const dirName = dirLink.split("/").slice(-2, -1)[0]; // 获取子目录名称


### PR DESCRIPTION
Subdirectory traversal may mistake the parent path as a subdirectory, resulting in an incorrect video address in the end.