### PR TITLE
feat(zen): active-time reminder model + iOS-style snooze

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "macify",
-  "version": "2.0.1-dev",
+  "version": "2.0.2-dev",
   "private": true,
   "description": "Transform Chrome's new tab into a macOS aerial screensaver.",
   "license": "MIT",

--- a/src/_locales/en/messages.json
+++ b/src/_locales/en/messages.json
@@ -386,8 +386,8 @@
   "zen_reminder_cta": {
     "message": "Enter Zen"
   },
-  "zen_reminder_dismiss": {
-    "message": "Later"
+  "zen_reminder_snooze": {
+    "message": "Snooze"
   },
   "options_zen_reminder_prefix": {
     "message": "every"

--- a/src/_locales/ja/messages.json
+++ b/src/_locales/ja/messages.json
@@ -386,7 +386,7 @@
   "zen_reminder_cta": {
     "message": "禅モードへ"
   },
-  "zen_reminder_dismiss": {
+  "zen_reminder_snooze": {
     "message": "あとで"
   },
   "options_zen_reminder_prefix": {

--- a/src/_locales/zh_CN/messages.json
+++ b/src/_locales/zh_CN/messages.json
@@ -386,7 +386,7 @@
   "zen_reminder_cta": {
     "message": "进入禅意"
   },
-  "zen_reminder_dismiss": {
+  "zen_reminder_snooze": {
     "message": "稍后"
   },
   "options_zen_reminder_prefix": {

--- a/src/_locales/zh_TW/messages.json
+++ b/src/_locales/zh_TW/messages.json
@@ -386,7 +386,7 @@
   "zen_reminder_cta": {
     "message": "進入禪意"
   },
-  "zen_reminder_dismiss": {
+  "zen_reminder_snooze": {
     "message": "稍後"
   },
   "options_zen_reminder_prefix": {

--- a/src/background.js
+++ b/src/background.js
@@ -1,3 +1,24 @@
+import { beginAway, endAway } from './lib/zen-tracking.js';
+
+// chrome.idle minimum is 15s; default is 60s. 60s avoids churning state
+// for brief desk-shifts but still catches a real lock or step-away
+// quickly. Re-setting on each service-worker wake is idempotent.
+chrome.idle.setDetectionInterval(60);
+
+chrome.idle.onStateChanged.addListener(async (state) => {
+  try {
+    if (state === 'active') {
+      await endAway();
+    } else {
+      // 'idle' or 'locked' — both pause the active accumulator. A long
+      // enough away period is later treated as a natural break.
+      await beginAway();
+    }
+  } catch {
+    // best-effort
+  }
+});
+
 chrome.runtime.onInstalled.addListener(async (details) => {
   if (details.reason === 'install') {
     // Stamp install time so the donate prompt can compute "days since install".

--- a/src/lib/zen-reminder.js
+++ b/src/lib/zen-reminder.js
@@ -1,50 +1,49 @@
-// Zen break-reminder candidate. Logic was previously embedded in
+// Zen break-reminder pill candidate. Logic was previously embedded in
 // ZenReminderPill.svelte; extracted here so the new tab page can
 // orchestrate multiple pill candidates through a single PillStack.
 //
 // Reminder fires only on new-tab open, never via setInterval — keeps
 // it from interrupting deep work in an already-open tab.
 //
-// Storage: chrome.storage.session, NOT local. The cooldown should
-// reset on every Chrome cold start; otherwise the pill greets the
-// user with "you've been working for 8h" first thing in the morning.
+// "How long has the user been working" is computed by zen-tracking.js,
+// which excludes locked/idle stretches. See that file for the model.
 //
-// lastZenSessionAt: ms — last time Zen actually started OR a reminder
-// pill was rendered. Either counts as "the reminder happened" so it
-// won't fire again until the next interval is up.
+// Dismissal is iOS-alarm-style snooze: the reminder is suppressed for
+// SNOOZE_MS (9 min), then returns showing the new (still-elevated)
+// active-time number. Only entering Zen actually resets the cycle.
 
 import IconZazen from '~icons/mingcute/zazen-line';
 import { settings } from './settings.svelte.js';
 import { t } from './i18n.svelte.js';
 import { enterZen } from './zen.svelte.js';
+import {
+  getEffectiveActiveMs,
+  isSnoozed,
+  snoozeReminder,
+  SNOOZE_MS,
+  SHOW_DEBOUNCE_MS,
+} from './zen-tracking.js';
 
 export async function checkZenReminderPill() {
   if (!settings.zenReminderEnabled) return null;
   const interval = Number(settings.zenReminderMinutes) || 0;
   if (interval <= 0) return null;
 
-  let lastZenSessionAt;
   try {
-    const data = await chrome.storage.session.get('lastZenSessionAt');
-    lastZenSessionAt = data.lastZenSessionAt;
+    if (await isSnoozed()) return null;
   } catch {
     return null;
   }
 
-  const now = Date.now();
-  // First-run case: no anchor, treat now as the start. Don't fire
-  // immediately — wait one full interval.
-  if (!lastZenSessionAt) {
-    try {
-      await chrome.storage.session.set({ lastZenSessionAt: now });
-    } catch {}
+  let activeMs;
+  try {
+    activeMs = await getEffectiveActiveMs();
+  } catch {
     return null;
   }
+  if (activeMs < interval * 60_000) return null;
 
-  const elapsedMs = now - lastZenSessionAt;
-  if (elapsedMs < interval * 60_000) return null;
-
-  const elapsedMinutes = Math.floor(elapsedMs / 60_000);
+  const elapsedMinutes = Math.floor(activeMs / 60_000);
 
   return {
     icon: IconZazen,
@@ -53,19 +52,24 @@ export async function checkZenReminderPill() {
     cta: {
       label: t('zen_reminder_cta'),
       onClick: async () => {
-        // enterZen() also stamps lastZenSessionAt — fine, idempotent
-        // here since onShow already stamped before render.
+        // enterZen() resets the active-time tracker.
         await enterZen();
       },
     },
-    dismissLabel: t('zen_reminder_dismiss'),
+    dismissLabel: t('zen_reminder_snooze'),
     onShow: async () => {
-      // Stamp BEFORE rendering so a concurrent / immediately following
-      // new-tab page doesn't double-fire.
+      // Brief auto-suppress so opening several new tabs in a row
+      // doesn't re-render the same pill in each one.
       try {
-        await chrome.storage.session.set({ lastZenSessionAt: now });
+        await snoozeReminder(SHOW_DEBOUNCE_MS);
       } catch {}
     },
-    // No onDismiss — onShow already stamped; ✕ is just UI dismissal.
+    onDismiss: async () => {
+      // iOS-alarm-style snooze. The active-time accumulator keeps
+      // ticking; the pill returns later showing the new total.
+      try {
+        await snoozeReminder(SNOOZE_MS);
+      } catch {}
+    },
   };
 }

--- a/src/lib/zen-tracking.js
+++ b/src/lib/zen-tracking.js
@@ -1,0 +1,133 @@
+// Active-work-time tracker for the Zen break reminder.
+//
+// Older versions used wall-clock elapsed time since the last reminder.
+// That over-counts: a locked screen overnight or a long meeting in
+// another app would still tick up the timer, so the pill could greet
+// the user with "you've been at the screen for 456 min" the moment
+// Chrome regained focus.
+//
+// New model: accumulate time only while chrome.idle reports `active`.
+// A long enough idle/locked stretch is treated as a *natural break* and
+// fully resets the accumulator — the user already took the break we
+// would have nudged them toward.
+//
+// All state lives in chrome.storage.session so it wipes on Chrome cold
+// start; opening a fresh browser shouldn't surface a stale pill.
+//
+// Storage shape:
+//   zenActiveStartedAt    — ms; current active period began here.
+//                           Cleared while away.
+//   zenAccumulatedActiveMs — ms; active time banked since last reset.
+//   zenAwayAt             — ms; idle/locked period began here.
+//                           Cleared on return.
+//   zenSnoozedUntil       — ms; reminder is suppressed until this time.
+
+// Treat away periods of at least this long as a real break.
+// Shorter than this: pause and resume so a quick coffee run doesn't
+// reset a real working session. Longer: assume the body got what the
+// pill would have suggested anyway.
+const NATURAL_BREAK_MS = 5 * 60_000;
+
+// iOS-alarm-style snooze duration applied when the user dismisses the
+// pill. Fixed (not user-configurable) for the same reason iOS picked
+// 9 minutes: a single, predictable number means users learn the
+// behavior instead of fiddling with it.
+export const SNOOZE_MS = 9 * 60_000;
+
+// Brief auto-suppress after the pill is shown. Without this, opening
+// several new tabs in quick succession would re-render the same pill
+// in each one. 30s is enough to read the message and decide.
+export const SHOW_DEBOUNCE_MS = 30_000;
+
+const KEYS = [
+  'zenActiveStartedAt',
+  'zenAccumulatedActiveMs',
+  'zenAwayAt',
+  'zenSnoozedUntil',
+];
+
+async function read() {
+  return chrome.storage.session.get(KEYS);
+}
+
+/**
+ * Called when chrome.idle transitions to `idle` or `locked`. Flushes any
+ * in-progress active duration into the accumulator and stamps the away
+ * timestamp so the eventual return can decide whether it was a real
+ * break.
+ */
+export async function beginAway(now = Date.now()) {
+  const s = await read();
+  const set = { zenAwayAt: now };
+  if (s.zenActiveStartedAt) {
+    const delta = Math.max(0, now - s.zenActiveStartedAt);
+    set.zenAccumulatedActiveMs = (s.zenAccumulatedActiveMs || 0) + delta;
+  }
+  await chrome.storage.session.set(set);
+  await chrome.storage.session.remove('zenActiveStartedAt');
+}
+
+/**
+ * Called when chrome.idle transitions back to `active`. If the away
+ * period was long enough, treats it as a natural break (full reset);
+ * otherwise resumes the previous accumulator. Idempotent: also called
+ * from the reminder check to handle the race where a new tab opens
+ * before the idle event lands.
+ */
+export async function endAway(now = Date.now()) {
+  const s = await read();
+  if (s.zenAwayAt == null) {
+    if (s.zenActiveStartedAt == null) {
+      await chrome.storage.session.set({ zenActiveStartedAt: now });
+    }
+    return;
+  }
+  const breakMs = now - s.zenAwayAt;
+  if (breakMs >= NATURAL_BREAK_MS) {
+    await chrome.storage.session.set({
+      zenActiveStartedAt: now,
+      zenAccumulatedActiveMs: 0,
+    });
+    // The user already broke; clear any pending snooze too — they
+    // shouldn't come back to a silenced reminder from before the break.
+    await chrome.storage.session.remove(['zenAwayAt', 'zenSnoozedUntil']);
+  } else {
+    await chrome.storage.session.set({ zenActiveStartedAt: now });
+    await chrome.storage.session.remove('zenAwayAt');
+  }
+}
+
+/**
+ * Total active milliseconds since the last natural break or Zen
+ * session — banked accumulator plus the in-progress active period.
+ *
+ * Side-effects: calls endAway() to handle the new-tab-immediately-
+ * after-unlock race. The reminder check is the only caller, so this
+ * stays consistent.
+ */
+export async function getEffectiveActiveMs(now = Date.now()) {
+  await endAway(now);
+  const s = await read();
+  const ongoing = s.zenActiveStartedAt
+    ? Math.max(0, now - s.zenActiveStartedAt)
+    : 0;
+  return (s.zenAccumulatedActiveMs || 0) + ongoing;
+}
+
+/** Called by enterZen(): the user is taking a break, restart the cycle. */
+export async function resetTracking(now = Date.now()) {
+  await chrome.storage.session.set({
+    zenAccumulatedActiveMs: 0,
+    zenActiveStartedAt: now,
+  });
+  await chrome.storage.session.remove(['zenAwayAt', 'zenSnoozedUntil']);
+}
+
+export async function snoozeReminder(durationMs, now = Date.now()) {
+  await chrome.storage.session.set({ zenSnoozedUntil: now + durationMs });
+}
+
+export async function isSnoozed(now = Date.now()) {
+  const { zenSnoozedUntil } = await chrome.storage.session.get('zenSnoozedUntil');
+  return !!zenSnoozedUntil && now < zenSnoozedUntil;
+}

--- a/src/lib/zen.svelte.js
+++ b/src/lib/zen.svelte.js
@@ -3,14 +3,12 @@
 // via PillStack) call enterZen() from here, so a session can start
 // whether or not the new-tab UI is showing the button at the moment.
 //
-// Storage key (chrome.storage.session — wipes on Chrome cold start):
-//   lastZenSessionAt — ms timestamp set on every enterZen(); the reminder
-//   pill uses this to compute "minutes since last session". Using session
-//   storage instead of local means the cooldown resets each time Chrome
-//   restarts, so users don't get hit with a stale "X hours ago" pill on
-//   first launch of the day.
+// enterZen() resets the reminder tracker (lib/zen-tracking.js) so the
+// next reminder is one full interval away. See that file for the
+// active-time model.
 
 import { settings } from './settings.svelte.js';
+import { resetTracking } from './zen-tracking.js';
 
 const MUSIC_BASE = `${import.meta.env.VITE_MACIFY_BASE}/music/`;
 const TRACK_COUNT = 40;
@@ -77,8 +75,8 @@ function fadeAudioOut(durationMs) {
 
 /**
  * Enter Zen mode: fullscreen the video stage, optionally start music,
- * optionally start the auto-exit timer. Stamps lastZenSessionAt so the
- * reminder pill cooldown begins now.
+ * optionally start the auto-exit timer. Resets the active-time tracker
+ * so the next break reminder is one full interval away.
  *
  * Must be called from a user gesture (browser fullscreen + autoplay rules).
  */
@@ -99,9 +97,10 @@ export async function enterZen() {
 
   zen.active = true;
 
-  // Reset the reminder cooldown timer.
+  // Reset the active-time tracker — taking a real break starts the
+  // cycle over.
   try {
-    await chrome.storage.session.set({ lastZenSessionAt: Date.now() });
+    await resetTracking();
   } catch {
     // best-effort, swallow
   }

--- a/src/manifest.config.js
+++ b/src/manifest.config.js
@@ -23,5 +23,5 @@ export default defineManifest({
   chrome_url_overrides: {
     newtab: 'popup/index.html',
   },
-  permissions: ['storage', 'topSites', 'favicon'],
+  permissions: ['storage', 'topSites', 'favicon', 'idle'],
 });


### PR DESCRIPTION
Replace wall-clock timing with chrome.idle-driven active-time accumulation. Locked screen and idle periods >= 5 min count as natural breaks (full reset) rather than work — fixes the "you've been at the screen for 456 min" pill that appeared right after unlocking.

Pill dismissal becomes a 9-min snooze (iOS alarm pattern) instead of silently resetting the full interval. Entering Zen still resets the tracker.

State machine extracted to src/lib/zen-tracking.js, shared by background.js (idle listener) and zen-reminder.js (pill check). Requires the new `idle` permission. Rationale documented in KH ADR-0002.