### PR TITLE
Add scoped aerial shuffle controls

### DIFF
--- a/src/_locales/en/messages.json
+++ b/src/_locales/en/messages.json
@@ -65,6 +65,30 @@
   "options_video_local_url": {
     "message": "Local server URL"
   },
+  "options_video_shuffle_scope": {
+    "message": "Shuffle range"
+  },
+  "options_video_shuffle_scope_hint": {
+    "message": "If the selected category has no videos in the current source, all videos will play instead."
+  },
+  "shuffle_scope_all": {
+    "message": "All"
+  },
+  "shuffle_scope_landscape": {
+    "message": "Landscape"
+  },
+  "shuffle_scope_cityscape": {
+    "message": "Cityscape"
+  },
+  "shuffle_scope_underwater": {
+    "message": "Underwater"
+  },
+  "shuffle_scope_space": {
+    "message": "Earth"
+  },
+  "shuffle_scope_mac": {
+    "message": "Mac"
+  },
   "refresh_video": {
     "message": "Switch video"
   },

--- a/src/_locales/ja/messages.json
+++ b/src/_locales/ja/messages.json
@@ -65,6 +65,30 @@
   "options_video_local_url": {
     "message": "ローカルサーバーのURL"
   },
+  "options_video_shuffle_scope": {
+    "message": "シャッフル範囲"
+  },
+  "options_video_shuffle_scope_hint": {
+    "message": "現在のソースに選択したカテゴリの動画がない場合、すべての動画が再生されます。"
+  },
+  "shuffle_scope_all": {
+    "message": "すべて"
+  },
+  "shuffle_scope_landscape": {
+    "message": "ランドスケープ"
+  },
+  "shuffle_scope_cityscape": {
+    "message": "シティスケープ"
+  },
+  "shuffle_scope_underwater": {
+    "message": "水中"
+  },
+  "shuffle_scope_space": {
+    "message": "地球"
+  },
+  "shuffle_scope_mac": {
+    "message": "Mac"
+  },
   "refresh_video": {
     "message": "動画を切り替え"
   },

--- a/src/_locales/zh_CN/messages.json
+++ b/src/_locales/zh_CN/messages.json
@@ -65,6 +65,30 @@
   "options_video_local_url": {
     "message": "本地服务器地址"
   },
+  "options_video_shuffle_scope": {
+    "message": "随机范围"
+  },
+  "options_video_shuffle_scope_hint": {
+    "message": "如果当前视频源中没有所选类别的视频，将改为播放所有视频。"
+  },
+  "shuffle_scope_all": {
+    "message": "所有视频"
+  },
+  "shuffle_scope_landscape": {
+    "message": "自然景观"
+  },
+  "shuffle_scope_cityscape": {
+    "message": "城市景观"
+  },
+  "shuffle_scope_underwater": {
+    "message": "水下"
+  },
+  "shuffle_scope_space": {
+    "message": "地球"
+  },
+  "shuffle_scope_mac": {
+    "message": "Mac"
+  },
   "refresh_video": {
     "message": "切换视频"
   },

--- a/src/_locales/zh_TW/messages.json
+++ b/src/_locales/zh_TW/messages.json
@@ -65,6 +65,30 @@
   "options_video_local_url": {
     "message": "本地伺服器位址"
   },
+  "options_video_shuffle_scope": {
+    "message": "隨機範圍"
+  },
+  "options_video_shuffle_scope_hint": {
+    "message": "如果目前影片來源中沒有所選類別的影片，將改為播放所有影片。"
+  },
+  "shuffle_scope_all": {
+    "message": "所有影片"
+  },
+  "shuffle_scope_landscape": {
+    "message": "自然景觀"
+  },
+  "shuffle_scope_cityscape": {
+    "message": "城市景觀"
+  },
+  "shuffle_scope_underwater": {
+    "message": "水下"
+  },
+  "shuffle_scope_space": {
+    "message": "地球"
+  },
+  "shuffle_scope_mac": {
+    "message": "Mac"
+  },
   "refresh_video": {
     "message": "切換影片"
   },

--- a/src/components/VideoBackground.svelte
+++ b/src/components/VideoBackground.svelte
@@ -8,6 +8,11 @@
     isAppleProxyFailed,
   } from '../lib/video-source.js';
   import { nowPlaying, registerVideoNext } from '../lib/now-playing.svelte.js';
+  import {
+    normalizeShuffleScopes,
+    pickInitialVideoIndex,
+    pickNextVideoIndex,
+  } from '../lib/shuffle-scope.js';
 
   let items = $state([]);
   let currentIndex = $state(-1);
@@ -15,6 +20,8 @@
   let errorMessage = $state('');
   let consecutiveErrors = 0;
   let proxyFallbackUsedThisLoad = false;
+  let activeShuffleScopesKey = JSON.stringify(normalizeShuffleScopes(settings.shuffleScopes));
+  let transitionTimer = null;
 
   const current = $derived(currentIndex >= 0 ? items[currentIndex] : null);
   const currentUrl = $derived(current?.url ?? '');
@@ -39,7 +46,7 @@
             : t('error_video_apple');
         return;
       }
-      currentIndex = Math.floor(Math.random() * items.length);
+      currentIndex = pickInitialVideoIndex(items, settings.shuffleScopes);
       opacity = 0;
     } catch (e) {
       console.error('Playlist load failed:', e);
@@ -58,6 +65,15 @@
   });
 
   $effect(() => {
+    const scopes = normalizeShuffleScopes(settings.shuffleScopes);
+    const scopeKey = JSON.stringify(scopes);
+    if (scopeKey === activeShuffleScopesKey) return;
+    activeShuffleScopesKey = scopeKey;
+    if (items.length === 0) return;
+    scheduleVideoChange(scopes);
+  });
+
+  $effect(() => {
     nowPlaying.item = current;
   });
 
@@ -66,12 +82,32 @@
     return () => registerVideoNext(null);
   });
 
-  function nextVideo() {
+  $effect(() => {
+    return () => clearTransitionTimer();
+  });
+
+  function clearTransitionTimer() {
+    if (!transitionTimer) return;
+    clearTimeout(transitionTimer);
+    transitionTimer = null;
+  }
+
+  function scheduleVideoChange(scopes) {
     if (items.length === 0) return;
+    clearTransitionTimer();
     opacity = 0;
-    setTimeout(() => {
-      currentIndex = (currentIndex + 1) % items.length;
+    transitionTimer = setTimeout(() => {
+      currentIndex = pickNextVideoIndex(items, currentIndex, scopes);
+      transitionTimer = null;
     }, 650);
+  }
+
+  function nextVideo(options = {}) {
+    const scopes = normalizeShuffleScopes(options.scopes ?? settings.shuffleScopes);
+    if (options.setActiveScope) {
+      activeShuffleScopesKey = JSON.stringify(scopes);
+    }
+    scheduleVideoChange(scopes);
   }
 
   function onCanPlay() {

--- a/src/lib/defaults.js
+++ b/src/lib/defaults.js
@@ -17,6 +17,7 @@ export const DEFAULTS = Object.freeze({
   authorInfo: true,
   videoSrc: 'apple',
   reverseProxy: true,
+  shuffleScopes: ['all'],
   showVideoMetadata: true,
   translateMotto: false,
   zenMusic: true,

--- a/src/lib/now-playing.svelte.js
+++ b/src/lib/now-playing.svelte.js
@@ -9,6 +9,6 @@ let nextHandler = null;
 export function registerVideoNext(fn) {
   nextHandler = fn;
 }
-export function requestVideoNext() {
-  nextHandler?.();
+export function requestVideoNext(options) {
+  nextHandler?.(options);
 }

--- a/src/lib/shuffle-scope.js
+++ b/src/lib/shuffle-scope.js
@@ -1,0 +1,73 @@
+export const SHUFFLE_SCOPE_OPTIONS = Object.freeze([
+  { value: 'all', labelKey: 'shuffle_scope_all', category: null },
+  { value: 'landscapes', labelKey: 'shuffle_scope_landscape', category: 'Landscapes' },
+  { value: 'cities', labelKey: 'shuffle_scope_cityscape', category: 'Cities' },
+  { value: 'underwater', labelKey: 'shuffle_scope_underwater', category: 'Underwater' },
+  { value: 'space', labelKey: 'shuffle_scope_space', category: 'Space' },
+  { value: 'mac', labelKey: 'shuffle_scope_mac', category: 'Mac' },
+]);
+
+const OPTION_BY_VALUE = new Map(SHUFFLE_SCOPE_OPTIONS.map((o) => [o.value, o]));
+
+function normalizeShuffleScope(scope) {
+  return OPTION_BY_VALUE.has(scope) ? scope : 'all';
+}
+
+export function normalizeShuffleScopes(scopes) {
+  const raw = Array.isArray(scopes) ? scopes : [scopes];
+  const normalized = raw.map(normalizeShuffleScope).filter(Boolean);
+  if (normalized.length === 0 || normalized.includes('all')) return ['all'];
+  return [...new Set(normalized)];
+}
+
+export function primaryShuffleScope(scopes) {
+  return normalizeShuffleScopes(scopes)[0] ?? 'all';
+}
+
+export function itemsForShuffleScopes(items, scopes) {
+  const normalized = normalizeShuffleScopes(scopes);
+  if (normalized.includes('all')) return items;
+
+  const categories = new Set(
+    normalized.map((scope) => OPTION_BY_VALUE.get(scope)?.category).filter(Boolean),
+  );
+  return items.filter((item) => categories.has(item.meta?.category));
+}
+
+function randomIndexFromPool(items, pool, currentIndex = -1) {
+  const current = currentIndex >= 0 ? items[currentIndex] : null;
+  let candidates = pool;
+
+  if (current && candidates.length > 1) {
+    candidates = candidates.filter((item) => item !== current);
+  }
+
+  if (candidates.length === 0) {
+    return currentIndex >= 0 ? currentIndex : 0;
+  }
+
+  const pick = candidates[Math.floor(Math.random() * candidates.length)];
+  const index = items.indexOf(pick);
+  return index >= 0 ? index : 0;
+}
+
+export function pickInitialVideoIndex(items, scopes = ['all']) {
+  if (items.length === 0) return -1;
+  const scopedItems = itemsForShuffleScopes(items, scopes);
+  const pool = scopedItems.length > 0 ? scopedItems : items;
+  return randomIndexFromPool(items, pool);
+}
+
+export function pickNextVideoIndex(items, currentIndex = -1, scopes = ['all']) {
+  if (items.length === 0) return -1;
+
+  const normalized = normalizeShuffleScopes(scopes);
+  const scopedItems = itemsForShuffleScopes(items, normalized);
+  const isAllOrFallback = normalized.includes('all') || scopedItems.length === 0;
+
+  if (isAllOrFallback) {
+    return currentIndex >= 0 ? (currentIndex + 1) % items.length : 0;
+  }
+
+  return randomIndexFromPool(items, scopedItems, currentIndex);
+}

--- a/src/options/sections/VideoSection.svelte
+++ b/src/options/sections/VideoSection.svelte
@@ -1,8 +1,22 @@
 <script>
-  import { settings, bindSetting } from '../../lib/settings.svelte.js';
+  import {
+    settings,
+    updateSetting,
+    bindSetting,
+  } from '../../lib/settings.svelte.js';
   import { t } from '../../lib/i18n.svelte.js';
+  import {
+    SHUFFLE_SCOPE_OPTIONS,
+    primaryShuffleScope,
+  } from '../../lib/shuffle-scope.js';
   import SettingsCard from './SettingsCard.svelte';
   import VideoSetupHelp from '../VideoSetupHelp.svelte';
+
+  const selectedScope = $derived(primaryShuffleScope(settings.shuffleScopes));
+
+  function setShuffleScope(event) {
+    return updateSetting('shuffleScopes', [event.currentTarget.value]);
+  }
 </script>
 
 <SettingsCard emoji="📺" title={t('options_video_section')}>
@@ -20,6 +34,24 @@
         <option value="local">{t('options_video_source_local')}</option>
       </select>
     </label>
+
+    <label class="flex items-center justify-between gap-4">
+      <span class="text-sm text-slate-700">
+        {t('options_video_shuffle_scope')}
+      </span>
+      <select
+        class="rounded-md border border-slate-300 bg-white px-3 py-1.5 text-sm shadow-sm focus:border-blue-500 focus:ring-2 focus:ring-blue-500/20 focus:outline-none"
+        value={selectedScope}
+        onchange={setShuffleScope}
+      >
+        {#each SHUFFLE_SCOPE_OPTIONS as scope}
+          <option value={scope.value}>{t(scope.labelKey)}</option>
+        {/each}
+      </select>
+    </label>
+    <p class="text-xs leading-relaxed text-slate-500">
+      {t('options_video_shuffle_scope_hint')}
+    </p>
 
     {#if settings.videoSrc === 'apple'}
       <label class="flex items-center justify-between gap-4">


### PR DESCRIPTION
## Context

macOS's built-in Aerial screen saver lets users shuffle within meaningful groups such as Landscape, Cityscape, Underwater, and Earth. Macify already has rich category metadata for the bundled Aerial catalog, but the new-tab refresh button currently advances across the full playlist. In practice, jumping between unrelated themes can feel visually abrupt.

This PR adds scoped shuffle controls in Options so users can keep switching within a chosen Aerial range while preserving the existing All behavior.

## Changes

- Add a shared shuffle-scope helper for category mapping and next-video selection.
- Add a new shuffleScopes array setting for future multi-select support; v1 exposes a single-select UI.
- Default the shuffle range to All so existing users keep their current behavior after upgrading.
- Preserve the old sequential next-video behavior when the selected range is All.
- Use random switching only when a specific category is selected.
- Add a Shuffle range selector to Options -> Video.
- Fall back to All at runtime when the selected scope has no playable videos in the current source.
- Document the fallback policy in Options without implying the stored selection was overridden.
- Keep internal values aligned with Apple's catalog categories, including the Space value, while the UI label remains Earth.
- Clear pending transition timers before scheduling a new video change.
- Add i18n strings for English, Simplified Chinese, Traditional Chinese, and Japanese.

## Testing

- VITE_MACIFY_BASE=https://example.com npm run build
- git diff --check
- Parsed all locale JSON files.
- Verified the bundled catalog scope counts locally: All 156, Landscape 79, Cityscape 30, Underwater 21, Space/Earth 22, Mac 4.
- Verified All uses sequential next-video behavior.
- Verified Underwater scoped next-video picks stay inside the Underwater category.
- Verified invalid scope values normalize to All.
