### PR TITLE
Add Macify product site with 4K hero

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,6 +8,7 @@ localvideoserver.conf
 
 node_modules/
 dist/
+site-dist/
 releases/
 *.zip
 

--- a/package.json
+++ b/package.json
@@ -7,8 +7,12 @@
   "type": "module",
   "scripts": {
     "dev": "vite",
+    "dev:site": "vite --config vite.site.config.js",
     "build": "vite build",
+    "build:site": "vite build --config vite.site.config.js",
     "preview": "vite preview",
+    "preview:site": "vite preview --config vite.site.config.js",
+    "deploy:site": "npm run build:site && npx wrangler pages deploy site-dist --project-name macify-candobear-com --branch main",
     "zip": "node scripts/zip.js",
     "build:quotes": "node scripts/build-quotes.mjs",
     "build:videos": "node scripts/build-videos.mjs",

--- a/site/README.md
+++ b/site/README.md
@@ -25,3 +25,14 @@ For direct uploads after Wrangler authentication:
 ```bash
 npm run deploy:site
 ```
+
+## Media assets
+
+Large hero media is hosted outside the Pages build in R2.
+
+- Bucket: `macify-candobear-com-assets`
+- Public media domain: `media.macify.candobear.com`
+- Hero video: `hero/palau-jellies-4k.mov`
+- Hero poster: `hero/palau-jellies-poster.jpg`
+
+Do not commit `.mov` files or generated media downloads to this repository.

--- a/site/README.md
+++ b/site/README.md
@@ -1,0 +1,27 @@
+# Macify Product Site
+
+This directory contains the standalone Macify product page for `macify.candobear.com`.
+
+## Local development
+
+```bash
+npm run dev:site
+```
+
+## Build
+
+```bash
+npm run build:site
+```
+
+The site build is written to `site-dist/`, separate from the Chrome extension build in `dist/`.
+
+## Cloudflare Pages
+
+Use the project name `macify-candobear-com` and bind the custom domain `macify.candobear.com`.
+
+For direct uploads after Wrangler authentication:
+
+```bash
+npm run deploy:site
+```

--- a/site/index.html
+++ b/site/index.html
@@ -1,0 +1,22 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <meta
+      name="description"
+      content="Macify turns Chrome's new tab into a calm macOS Aerial-inspired dashboard with weather, top sites, quotes, and Zen mode."
+    />
+    <meta property="og:title" content="Macify - macOS Aerial Screensavers in Chrome's New Tab" />
+    <meta
+      property="og:description"
+      content="Replace Chrome's new tab page with macOS Aerial videos and a small set of calm, optional widgets."
+    />
+    <meta property="og:type" content="website" />
+    <title>Macify - macOS Aerial Screensavers in Chrome's New Tab</title>
+  </head>
+  <body>
+    <div id="app"></div>
+    <script type="module" src="/src/main.js"></script>
+  </body>
+</html>

--- a/site/src/App.svelte
+++ b/site/src/App.svelte
@@ -9,58 +9,58 @@
 
   const features = [
     {
-      title: 'macOS Aerial videos',
-      text: 'A curated 4K SDR Aerial catalog for a new tab that feels open, quiet, and alive.',
+      title: 'Aerial films',
+      text: '4K scenes from the macOS Aerial collection, made for a quieter tab.',
     },
     {
-      title: 'Live weather',
-      text: 'Current conditions, forecast, sunrise, sunset, wind, UV, and air quality through Open-Meteo.',
+      title: 'Weather at a glance',
+      text: 'Temperature, forecast, sunrise, wind, UV, and air quality. No API key.',
     },
     {
-      title: 'Top sites',
-      text: "Fast access to Chrome's built-in most-visited list without asking for browsing history.",
+      title: 'Your top sites',
+      text: "Chrome's most-visited sites, without asking for your browsing history.",
     },
     {
-      title: 'Random quotes',
-      text: 'A calm center point for each new tab, drawn from a public-domain quote set.',
+      title: 'A quiet thought',
+      text: 'A simple quote in the middle of the screen. Nothing more.',
     },
     {
       title: 'Zen mode',
-      text: 'Fullscreen Aerial video with optional ambient music when you want a short visual reset.',
+      text: 'Let the video fill the screen, with optional ambient sound.',
     },
     {
       title: 'Four languages',
-      text: 'English, Simplified Chinese, Traditional Chinese, and Japanese are built in.',
+      text: 'English, Simplified Chinese, Traditional Chinese, and Japanese.',
     },
   ];
 
   const trustItems = [
     {
-      label: 'No history permission',
-      detail: 'Macify uses Chrome top sites instead of reading your browsing history.',
+      label: 'No browsing history',
+      detail: 'Macify uses Chrome top sites. It does not ask to read your history.',
     },
     {
       label: 'No weather API key',
-      detail: 'Weather runs on Open-Meteo, so there is no account setup or secret key.',
+      detail: 'Weather runs on Open-Meteo, with no account setup or secret key.',
     },
     {
-      label: 'Small permission set',
-      detail: 'Storage, top sites, favicon, and idle are the only requested permissions.',
+      label: 'Only what it needs',
+      detail: 'Storage, top sites, favicon, and idle are the only permissions.',
     },
   ];
 
   const sources = [
     {
       name: 'Apple Server',
-      summary: 'The default path streams Aerial videos from Apple, with an optional Cloudflare proxy for certificate handling.',
+      summary: 'Stream Aerial videos from Apple by default.',
     },
     {
       name: 'Cloudflare proxy',
-      summary: 'A Worker can proxy Apple Aerial requests and share the same host as other Macify media assets.',
+      summary: 'Use a Worker proxy when you want a shared media host.',
     },
     {
       name: 'Local server',
-      summary: 'macOS users can host downloaded Aerial videos locally for the fastest and most private playback.',
+      summary: 'Play downloaded Aerial videos from your own Mac.',
     },
   ];
 </script>
@@ -127,21 +127,12 @@
         </blockquote>
       </div>
 
-      <div class="scene-control left" aria-hidden="true">
-        <span></span>
-      </div>
-      <div class="scene-control-stack" aria-hidden="true">
-        <span class="grid-icon"></span>
-        <span class="refresh-icon"></span>
-      </div>
     </div>
 
     <div class="hero-content">
-      <p class="availability">Chrome Extension</p>
       <h1 id="hero-title">Macify</h1>
       <p class="hero-copy">
-        Turn Chrome's new tab into a calm macOS Aerial screen with weather, top sites,
-        quotes, and Zen mode.
+        Bring the Mac screensaver to every new tab.
       </p>
       <div class="hero-actions" aria-label="Primary actions">
         <a class="button primary" href={chromeStoreUrl}>Install from Chrome Web Store</a>
@@ -151,14 +142,17 @@
   </section>
 
   <section class="intro-band" aria-label="Macify summary">
-    <p>Macify keeps the new tab useful, quiet, and visually spacious.</p>
-    <p>macOS is not required. Any Chrome user can install it.</p>
+    <p>Open a tab. See the world.</p>
+    <p>Weather, sites, and quotes stay close. Never in the way.</p>
   </section>
 
   <section id="features" class="section features-section" aria-labelledby="features-title">
     <div class="section-heading">
-      <h2 id="features-title">A new tab that feels less like a dashboard.</h2>
-      <p>Everything on screen has a reason to be there. Nothing asks for attention unless you ask for it.</p>
+      <h2 id="features-title" class="split-title">
+        <span>Everything you need.</span>
+        <span>Nothing in the way.</span>
+      </h2>
+      <p>Aerial video leads. The small tools stay quiet until you need them.</p>
     </div>
     <div class="feature-grid">
       {#each features as feature}
@@ -172,8 +166,8 @@
 
   <section id="privacy" class="section trust-section" aria-labelledby="privacy-title">
     <div class="section-heading">
-      <h2 id="privacy-title">Useful without being nosy.</h2>
-      <p>Macify stays intentionally light on permissions and external dependencies.</p>
+      <h2 id="privacy-title">Your browsing stays yours.</h2>
+      <p>Macify keeps permissions light and avoids unnecessary accounts, keys, and tracking.</p>
     </div>
     <div class="trust-list">
       {#each trustItems as item}
@@ -187,8 +181,8 @@
 
   <section id="sources" class="section sources-section" aria-labelledby="sources-title">
     <div class="section-heading">
-      <h2 id="sources-title">Choose the video path that fits you.</h2>
-      <p>Start with the default Apple source, then move to Cloudflare or local hosting when you want more control.</p>
+      <h2 id="sources-title">Play it your way.</h2>
+      <p>Stream from Apple, proxy through Cloudflare, or use local files on your Mac.</p>
     </div>
     <div class="source-steps">
       {#each sources as source, index}
@@ -204,8 +198,11 @@
   </section>
 
   <section class="final-cta" aria-labelledby="final-title">
-    <h2 id="final-title">Make every new tab feel like a short visual reset.</h2>
-    <a class="button primary" href={chromeStoreUrl}>Install Macify</a>
+    <h2 id="final-title" class="split-title">
+      <span>Open a new tab.</span>
+      <span>Take a breath.</span>
+    </h2>
+    <a class="button primary" href={chromeStoreUrl}>Macify your Chrome, now!</a>
   </section>
 </main>
 

--- a/site/src/App.svelte
+++ b/site/src/App.svelte
@@ -1,0 +1,166 @@
+<script>
+  import screenshotUrl from '../../docs/screenshot.png';
+
+  const chromeStoreUrl =
+    'https://chromewebstore.google.com/detail/macify-macos-screensaver/lgdipcalomggcjkohjhkhkbcpgladnoe';
+  const githubUrl = 'https://github.com/jason5ng32/Macify';
+
+  const features = [
+    {
+      title: 'macOS Aerial videos',
+      text: 'A curated 4K SDR Aerial catalog for a new tab that feels open, quiet, and alive.',
+    },
+    {
+      title: 'Live weather',
+      text: 'Current conditions, forecast, sunrise, sunset, wind, UV, and air quality through Open-Meteo.',
+    },
+    {
+      title: 'Top sites',
+      text: "Fast access to Chrome's built-in most-visited list without asking for browsing history.",
+    },
+    {
+      title: 'Random quotes',
+      text: 'A calm center point for each new tab, drawn from a public-domain quote set.',
+    },
+    {
+      title: 'Zen mode',
+      text: 'Fullscreen Aerial video with optional ambient music when you want a short visual reset.',
+    },
+    {
+      title: 'Four languages',
+      text: 'English, Simplified Chinese, Traditional Chinese, and Japanese are built in.',
+    },
+  ];
+
+  const trustItems = [
+    {
+      label: 'No history permission',
+      detail: 'Macify uses Chrome top sites instead of reading your browsing history.',
+    },
+    {
+      label: 'No weather API key',
+      detail: 'Weather runs on Open-Meteo, so there is no account setup or secret key.',
+    },
+    {
+      label: 'Small permission set',
+      detail: 'Storage, top sites, favicon, and idle are the only requested permissions.',
+    },
+  ];
+
+  const sources = [
+    {
+      name: 'Apple Server',
+      summary: 'The default path streams Aerial videos from Apple, with an optional Cloudflare proxy for certificate handling.',
+    },
+    {
+      name: 'Cloudflare proxy',
+      summary: 'A Worker can proxy Apple Aerial requests and share the same host as other Macify media assets.',
+    },
+    {
+      name: 'Local server',
+      summary: 'macOS users can host downloaded Aerial videos locally for the fastest and most private playback.',
+    },
+  ];
+</script>
+
+<svelte:head>
+  <link rel="canonical" href="https://macify.candobear.com/" />
+</svelte:head>
+
+<header class="site-nav" aria-label="Primary navigation">
+  <a class="brand" href="#top" aria-label="Macify home">
+    <span class="brand-mark">M</span>
+    <span>Macify</span>
+  </a>
+  <nav>
+    <a href="#features">Features</a>
+    <a href="#privacy">Privacy</a>
+    <a href="#sources">Video sources</a>
+  </nav>
+</header>
+
+<main id="top">
+  <section class="hero" aria-labelledby="hero-title">
+    <img class="hero-image" src={screenshotUrl} alt="Macify new tab showing an aerial tea garden background with time, quote, and weather widgets." />
+    <div class="hero-shade"></div>
+    <div class="hero-content">
+      <p class="availability">Chrome Extension</p>
+      <h1 id="hero-title">Macify</h1>
+      <p class="hero-copy">
+        Turn Chrome's new tab into a calm macOS Aerial screen with weather, top sites,
+        quotes, and Zen mode.
+      </p>
+      <div class="hero-actions" aria-label="Primary actions">
+        <a class="button primary" href={chromeStoreUrl}>Install from Chrome Web Store</a>
+        <a class="button secondary" href={githubUrl}>View on GitHub</a>
+      </div>
+    </div>
+  </section>
+
+  <section class="intro-band" aria-label="Macify summary">
+    <p>Macify keeps the new tab useful, quiet, and visually spacious.</p>
+    <p>macOS is not required. Any Chrome user can install it.</p>
+  </section>
+
+  <section id="features" class="section features-section" aria-labelledby="features-title">
+    <div class="section-heading">
+      <h2 id="features-title">A new tab that feels less like a dashboard.</h2>
+      <p>Everything on screen has a reason to be there. Nothing asks for attention unless you ask for it.</p>
+    </div>
+    <div class="feature-grid">
+      {#each features as feature}
+        <article class="feature-card">
+          <h3>{feature.title}</h3>
+          <p>{feature.text}</p>
+        </article>
+      {/each}
+    </div>
+  </section>
+
+  <section id="privacy" class="section trust-section" aria-labelledby="privacy-title">
+    <div class="section-heading">
+      <h2 id="privacy-title">Useful without being nosy.</h2>
+      <p>Macify stays intentionally light on permissions and external dependencies.</p>
+    </div>
+    <div class="trust-list">
+      {#each trustItems as item}
+        <article>
+          <span>{item.label}</span>
+          <p>{item.detail}</p>
+        </article>
+      {/each}
+    </div>
+  </section>
+
+  <section id="sources" class="section sources-section" aria-labelledby="sources-title">
+    <div class="section-heading">
+      <h2 id="sources-title">Choose the video path that fits you.</h2>
+      <p>Start with the default Apple source, then move to Cloudflare or local hosting when you want more control.</p>
+    </div>
+    <div class="source-steps">
+      {#each sources as source, index}
+        <article>
+          <span class="step-number">{String(index + 1).padStart(2, '0')}</span>
+          <div>
+            <h3>{source.name}</h3>
+            <p>{source.summary}</p>
+          </div>
+        </article>
+      {/each}
+    </div>
+  </section>
+
+  <section class="final-cta" aria-labelledby="final-title">
+    <h2 id="final-title">Make every new tab feel like a short visual reset.</h2>
+    <a class="button primary" href={chromeStoreUrl}>Install Macify</a>
+  </section>
+</main>
+
+<footer class="site-footer">
+  <p>MIT licensed. Created by Jason Ng, Dofy, and Setilis. Aerial videos are © Apple Inc.</p>
+  <div>
+    <a href={githubUrl}>GitHub</a>
+    <a href={chromeStoreUrl}>Chrome Web Store</a>
+    <a href="#privacy">Privacy and permissions</a>
+  </div>
+</footer>

--- a/site/src/App.svelte
+++ b/site/src/App.svelte
@@ -1,9 +1,11 @@
 <script>
-  import screenshotUrl from '../../docs/screenshot.png';
-
   const chromeStoreUrl =
     'https://chromewebstore.google.com/detail/macify-macos-screensaver/lgdipcalomggcjkohjhkhkbcpgladnoe';
   const githubUrl = 'https://github.com/jason5ng32/Macify';
+  const heroVideoUrl = 'https://media.macify.candobear.com/hero/palau-jellies-4k.mov';
+  const heroPosterUrl = 'https://media.macify.candobear.com/hero/palau-jellies-poster.jpg';
+
+  let heroVideoFailed = false;
 
   const features = [
     {
@@ -80,9 +82,60 @@
 </header>
 
 <main id="top">
-  <section class="hero" aria-labelledby="hero-title">
-    <img class="hero-image" src={screenshotUrl} alt="Macify new tab showing an aerial tea garden background with time, quote, and weather widgets." />
+  <section class:video-failed={heroVideoFailed} class="hero" aria-labelledby="hero-title">
+    <video
+      class="hero-video"
+      src={heroVideoUrl}
+      poster={heroPosterUrl}
+      autoplay
+      muted
+      loop
+      playsinline
+      preload="metadata"
+      aria-hidden="true"
+      onerror={() => (heroVideoFailed = true)}
+    ></video>
+    <img class="hero-poster-fallback" src={heroPosterUrl} alt="" aria-hidden="true" />
     <div class="hero-shade"></div>
+    <div class="macify-scene" aria-label="Macify new tab preview with Palau Jellies video, weather, quote, and quick controls.">
+      <div class="scene-location">
+        <span>Palau Jellies</span>
+        <small>Underwater</small>
+      </div>
+
+      <div class="scene-weather" aria-label="Sunny, 25 degrees, feels like 22 degrees.">
+        <span class="weather-sun" aria-hidden="true"></span>
+        <span class="weather-temp">25°</span>
+        <small>Feels like 22°</small>
+      </div>
+
+      <div class="scene-center">
+        <svg class="sky-arc" viewBox="0 0 420 128" role="img" aria-label="Sun path chart">
+          <path class="arc-fill" d="M20 86 C118 86 133 24 210 24 C287 24 302 86 400 86" />
+          <path class="arc-line active" d="M20 86 C118 86 133 24 210 24 C287 24 302 86 400 86" />
+          <path class="arc-line soft" d="M20 86 C108 86 138 72 210 86 C282 100 312 86 400 86" />
+          <path class="arc-line soft" d="M72 86 L210 24 L348 86" />
+          <line class="arc-axis" x1="20" y1="86" x2="400" y2="86" />
+          <line class="arc-axis vertical" x1="210" y1="24" x2="210" y2="110" />
+          <circle class="arc-node" cx="210" cy="86" r="8" />
+          <circle class="arc-node active" cx="210" cy="24" r="5" />
+          <text x="210" y="14" text-anchor="middle">12:23</text>
+        </svg>
+        <blockquote>
+          <p>To enjoy life, we must touch much of it lightly.</p>
+          <cite>Voltaire</cite>
+        </blockquote>
+      </div>
+
+      <div class="scene-control left" aria-hidden="true">
+        <span></span>
+      </div>
+      <div class="scene-control-stack" aria-hidden="true">
+        <span class="grid-icon"></span>
+        <span class="refresh-icon"></span>
+      </div>
+    </div>
+
     <div class="hero-content">
       <p class="availability">Chrome Extension</p>
       <h1 id="hero-title">Macify</h1>

--- a/site/src/App.svelte
+++ b/site/src/App.svelte
@@ -1,11 +1,110 @@
 <script>
+  import { onMount } from 'svelte';
+
   const chromeStoreUrl =
     'https://chromewebstore.google.com/detail/macify-macos-screensaver/lgdipcalomggcjkohjhkhkbcpgladnoe';
   const githubUrl = 'https://github.com/jason5ng32/Macify';
   const heroVideoUrl = 'https://media.macify.candobear.com/hero/palau-jellies-4k.mov';
   const heroPosterUrl = 'https://media.macify.candobear.com/hero/palau-jellies-poster.jpg';
+  const beijingForecastUrl =
+    'https://api.open-meteo.com/v1/forecast?latitude=39.9042&longitude=116.4074&current=temperature_2m,apparent_temperature,weather_code&daily=sunrise,sunset&timezone=Asia%2FShanghai&forecast_days=1';
+  const arcStartX = 20;
+  const arcEndX = 400;
+  const arcBaseY = 86;
+  const arcPeakLift = 62;
+
+  const clamp = (value, min, max) => Math.min(Math.max(value, min), max);
+  const roundTemp = (value) => Math.round(Number(value));
 
   let heroVideoFailed = false;
+  let now = new Date();
+  let weatherTemp = 25;
+  let feelsLikeTemp = 22;
+  let weatherCode = 0;
+  let sunriseMinutes = 5 * 60 + 5;
+  let sunsetMinutes = 19 * 60 + 18;
+
+  function getBeijingParts(date) {
+    const parts = new Intl.DateTimeFormat('en-US', {
+      timeZone: 'Asia/Shanghai',
+      hour: '2-digit',
+      minute: '2-digit',
+      hourCycle: 'h23',
+    }).formatToParts(date);
+    const byType = Object.fromEntries(parts.map((part) => [part.type, part.value]));
+
+    return {
+      hour: Number(byType.hour ?? 0),
+      minute: Number(byType.minute ?? 0),
+    };
+  }
+
+  function formatBeijingTime(date) {
+    const { hour, minute } = getBeijingParts(date);
+    return `${String(hour).padStart(2, '0')}:${String(minute).padStart(2, '0')}`;
+  }
+
+  function minutesFromIsoLocal(value) {
+    const time = value?.split('T')[1] ?? '';
+    const [hour = 0, minute = 0] = time.split(':').map(Number);
+    return hour * 60 + minute;
+  }
+
+  function getWeatherClass(code) {
+    if ([0, 1].includes(code)) return 'is-clear';
+    if ([2, 3].includes(code)) return 'is-cloudy';
+    if ([45, 48].includes(code)) return 'is-fog';
+    if ((code >= 51 && code <= 67) || (code >= 80 && code <= 82) || code >= 95) return 'is-rain';
+    if (code >= 71 && code <= 86) return 'is-snow';
+    return 'is-clear';
+  }
+
+  async function updateBeijingWeather() {
+    const response = await fetch(beijingForecastUrl);
+
+    if (!response.ok) {
+      throw new Error('Unable to load Beijing weather');
+    }
+
+    const data = await response.json();
+    weatherTemp = roundTemp(data.current?.temperature_2m ?? weatherTemp);
+    feelsLikeTemp = roundTemp(data.current?.apparent_temperature ?? feelsLikeTemp);
+    weatherCode = Number(data.current?.weather_code ?? weatherCode);
+    sunriseMinutes = minutesFromIsoLocal(data.daily?.sunrise?.[0]) || sunriseMinutes;
+    sunsetMinutes = minutesFromIsoLocal(data.daily?.sunset?.[0]) || sunsetMinutes;
+  }
+
+  onMount(() => {
+    const clockTimer = window.setInterval(() => {
+      now = new Date();
+    }, 60 * 1000);
+    const weatherTimer = window.setInterval(() => {
+      updateBeijingWeather().catch(() => {});
+    }, 15 * 60 * 1000);
+
+    updateBeijingWeather().catch(() => {});
+
+    return () => {
+      window.clearInterval(clockTimer);
+      window.clearInterval(weatherTimer);
+    };
+  });
+
+  $: beijingTime = formatBeijingTime(now);
+  $: beijingMinutes = (() => {
+    const { hour, minute } = getBeijingParts(now);
+    return hour * 60 + minute;
+  })();
+  $: daylightProgress = clamp(
+    (beijingMinutes - sunriseMinutes) / Math.max(sunsetMinutes - sunriseMinutes, 1),
+    0,
+    1,
+  );
+  $: skyX = arcStartX + daylightProgress * (arcEndX - arcStartX);
+  $: skyY = arcBaseY - Math.sin(daylightProgress * Math.PI) * arcPeakLift;
+  $: timeLabelX = clamp(skyX, 36, 384);
+  $: timeLabelY = Math.max(14, skyY - 10);
+  $: weatherClass = getWeatherClass(weatherCode);
 
   const features = [
     {
@@ -103,23 +202,26 @@
         <small>Underwater</small>
       </div>
 
-      <div class="scene-weather" aria-label="Sunny, 25 degrees, feels like 22 degrees.">
-        <span class="weather-sun" aria-hidden="true"></span>
-        <span class="weather-temp">25°</span>
-        <small>Feels like 22°</small>
+      <div
+        class="scene-weather"
+        aria-label={`Beijing weather, ${weatherTemp} degrees, feels like ${feelsLikeTemp} degrees.`}
+      >
+        <span class={`weather-icon ${weatherClass}`} aria-hidden="true"></span>
+        <span class="weather-temp">{weatherTemp}°</span>
+        <small>Beijing · Feels like {feelsLikeTemp}°</small>
       </div>
 
       <div class="scene-center">
-        <svg class="sky-arc" viewBox="0 0 420 128" role="img" aria-label="Sun path chart">
+        <svg class="sky-arc" viewBox="0 0 420 128" role="img" aria-label={`Beijing sun path, ${beijingTime}.`}>
           <path class="arc-fill" d="M20 86 C118 86 133 24 210 24 C287 24 302 86 400 86" />
           <path class="arc-line active" d="M20 86 C118 86 133 24 210 24 C287 24 302 86 400 86" />
           <path class="arc-line soft" d="M20 86 C108 86 138 72 210 86 C282 100 312 86 400 86" />
           <path class="arc-line soft" d="M72 86 L210 24 L348 86" />
           <line class="arc-axis" x1="20" y1="86" x2="400" y2="86" />
-          <line class="arc-axis vertical" x1="210" y1="24" x2="210" y2="110" />
-          <circle class="arc-node" cx="210" cy="86" r="8" />
-          <circle class="arc-node active" cx="210" cy="24" r="5" />
-          <text x="210" y="14" text-anchor="middle">12:23</text>
+          <line class="arc-axis vertical" x1={skyX} y1={skyY} x2={skyX} y2="110" />
+          <circle class="arc-node" cx={skyX} cy="86" r="8" />
+          <circle class="arc-node active" cx={skyX} cy={skyY} r="5" />
+          <text x={timeLabelX} y={timeLabelY} text-anchor="middle">{beijingTime}</text>
         </svg>
         <blockquote>
           <p>To enjoy life, we must touch much of it lightly.</p>

--- a/site/src/main.js
+++ b/site/src/main.js
@@ -1,0 +1,5 @@
+import { mount } from 'svelte';
+import App from './App.svelte';
+import './site.css';
+
+mount(App, { target: document.getElementById('app') });

--- a/site/src/site.css
+++ b/site/src/site.css
@@ -170,15 +170,54 @@ a {
   grid-column: 1 / -1;
 }
 
-.weather-sun {
+.weather-icon {
   position: relative;
   width: 22px;
   height: 22px;
   border-radius: 999px;
   background: #ffd449;
+}
+
+.weather-icon.is-clear {
+  background: #ffd449;
   box-shadow:
     0 0 18px rgba(255, 212, 73, 0.72),
     0 0 0 4px rgba(255, 212, 73, 0.12);
+}
+
+.weather-icon.is-cloudy,
+.weather-icon.is-fog {
+  border-radius: 12px;
+  background: rgba(234, 246, 250, 0.92);
+  box-shadow:
+    -8px 4px 0 -2px rgba(234, 246, 250, 0.76),
+    8px 4px 0 -2px rgba(234, 246, 250, 0.72),
+    0 0 18px rgba(234, 246, 250, 0.32);
+}
+
+.weather-icon.is-rain,
+.weather-icon.is-snow {
+  border-radius: 12px;
+  background: rgba(234, 246, 250, 0.92);
+  box-shadow:
+    -7px 4px 0 -2px rgba(234, 246, 250, 0.72),
+    7px 4px 0 -2px rgba(234, 246, 250, 0.68);
+}
+
+.weather-icon.is-rain::after,
+.weather-icon.is-snow::after {
+  position: absolute;
+  right: 2px;
+  bottom: -7px;
+  left: 2px;
+  height: 7px;
+  border-radius: 999px;
+  content: "";
+  background: repeating-linear-gradient(
+    90deg,
+    rgba(188, 235, 255, 0.88) 0 2px,
+    transparent 2px 6px
+  );
 }
 
 .scene-center {

--- a/site/src/site.css
+++ b/site/src/site.css
@@ -1,0 +1,469 @@
+@import 'tailwindcss';
+
+:root {
+  color: #eef7ef;
+  background: #07110d;
+  font-family:
+    Inter, ui-sans-serif, system-ui, -apple-system, BlinkMacSystemFont, "Segoe UI",
+    sans-serif;
+  font-synthesis: none;
+  text-rendering: optimizeLegibility;
+  -webkit-font-smoothing: antialiased;
+}
+
+* {
+  box-sizing: border-box;
+}
+
+html {
+  scroll-behavior: smooth;
+}
+
+body {
+  margin: 0;
+  min-width: 320px;
+  background: #07110d;
+}
+
+a {
+  color: inherit;
+  text-decoration: none;
+}
+
+.site-nav {
+  position: fixed;
+  inset: 0 0 auto;
+  z-index: 20;
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 24px;
+  padding: 18px clamp(20px, 5vw, 72px);
+  color: rgba(250, 255, 250, 0.92);
+  background: linear-gradient(180deg, rgba(6, 14, 10, 0.72), rgba(6, 14, 10, 0));
+}
+
+.brand {
+  display: inline-flex;
+  align-items: center;
+  gap: 10px;
+  font-size: 15px;
+  font-weight: 700;
+}
+
+.brand-mark {
+  display: grid;
+  width: 30px;
+  height: 30px;
+  place-items: center;
+  border: 1px solid rgba(255, 255, 255, 0.26);
+  border-radius: 8px;
+  background: rgba(255, 255, 255, 0.13);
+  color: #ffffff;
+}
+
+.site-nav nav {
+  display: flex;
+  align-items: center;
+  gap: clamp(14px, 3vw, 34px);
+  font-size: 14px;
+  font-weight: 600;
+}
+
+.site-nav nav a {
+  color: rgba(250, 255, 250, 0.78);
+}
+
+.site-nav nav a:hover {
+  color: #ffffff;
+}
+
+.hero {
+  position: relative;
+  min-height: 88svh;
+  overflow: hidden;
+  display: grid;
+  align-items: end;
+  padding: 128px clamp(20px, 5vw, 72px) 80px;
+  isolation: isolate;
+}
+
+.hero-image {
+  position: absolute;
+  inset: 0;
+  z-index: -3;
+  width: 100%;
+  height: 100%;
+  object-fit: cover;
+  object-position: center;
+  transform: scale(1.03);
+  animation: aerialDrift 22s ease-in-out infinite alternate;
+}
+
+.hero-shade {
+  position: absolute;
+  inset: 0;
+  z-index: -2;
+  background:
+    linear-gradient(90deg, rgba(5, 12, 8, 0.82) 0%, rgba(5, 12, 8, 0.48) 38%, rgba(5, 12, 8, 0.08) 72%),
+    linear-gradient(0deg, rgba(7, 17, 13, 0.78) 0%, rgba(7, 17, 13, 0.12) 44%, rgba(7, 17, 13, 0.38) 100%);
+}
+
+.hero-content {
+  width: min(680px, 100%);
+}
+
+.availability {
+  margin: 0 0 18px;
+  color: rgba(236, 255, 238, 0.78);
+  font-size: 15px;
+  font-weight: 700;
+}
+
+.hero h1 {
+  margin: 0;
+  color: #ffffff;
+  font-size: clamp(64px, 11vw, 146px);
+  font-weight: 800;
+  line-height: 0.9;
+  letter-spacing: 0;
+}
+
+.hero-copy {
+  max-width: 620px;
+  margin: 28px 0 0;
+  color: rgba(248, 255, 249, 0.9);
+  font-size: clamp(20px, 2.4vw, 30px);
+  line-height: 1.22;
+}
+
+.hero-actions {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 14px;
+  margin-top: 34px;
+}
+
+.button {
+  display: inline-flex;
+  min-height: 48px;
+  align-items: center;
+  justify-content: center;
+  border-radius: 8px;
+  padding: 0 20px;
+  font-size: 15px;
+  font-weight: 800;
+  transition:
+    transform 180ms ease,
+    background 180ms ease,
+    border-color 180ms ease;
+}
+
+.button:hover {
+  transform: translateY(-1px);
+}
+
+.button.primary {
+  background: #f5fff1;
+  color: #0b170f;
+}
+
+.button.secondary {
+  border: 1px solid rgba(255, 255, 255, 0.34);
+  background: rgba(255, 255, 255, 0.12);
+  color: #ffffff;
+}
+
+.intro-band {
+  display: grid;
+  grid-template-columns: minmax(0, 1fr) minmax(0, 1fr);
+  gap: 24px;
+  padding: 28px clamp(20px, 5vw, 72px);
+  background: #e9f3de;
+  color: #142017;
+}
+
+.intro-band p {
+  margin: 0;
+  font-size: clamp(18px, 2vw, 26px);
+  font-weight: 750;
+  line-height: 1.18;
+}
+
+.section {
+  padding: clamp(72px, 10vw, 132px) clamp(20px, 5vw, 72px);
+}
+
+.section-heading {
+  display: grid;
+  grid-template-columns: minmax(0, 0.94fr) minmax(260px, 0.56fr);
+  gap: clamp(28px, 6vw, 86px);
+  align-items: end;
+  margin-bottom: clamp(34px, 6vw, 64px);
+}
+
+.section-heading h2 {
+  margin: 0;
+  color: #f8fff7;
+  font-size: clamp(38px, 5.6vw, 78px);
+  font-weight: 800;
+  line-height: 0.98;
+  letter-spacing: 0;
+}
+
+.section-heading p {
+  margin: 0;
+  color: rgba(239, 249, 238, 0.68);
+  font-size: 18px;
+  line-height: 1.55;
+}
+
+.features-section {
+  background: #07110d;
+}
+
+.feature-grid {
+  display: grid;
+  grid-template-columns: repeat(3, minmax(0, 1fr));
+  gap: 1px;
+  border: 1px solid rgba(255, 255, 255, 0.12);
+  background: rgba(255, 255, 255, 0.12);
+}
+
+.feature-card {
+  min-height: 238px;
+  padding: clamp(24px, 3vw, 36px);
+  background: #0b1811;
+}
+
+.feature-card h3 {
+  margin: 0;
+  color: #f8fff7;
+  font-size: 22px;
+  line-height: 1.15;
+}
+
+.feature-card p {
+  margin: 20px 0 0;
+  color: rgba(239, 249, 238, 0.68);
+  font-size: 16px;
+  line-height: 1.58;
+}
+
+.trust-section {
+  background: #dfeccf;
+  color: #101b13;
+}
+
+.trust-section .section-heading h2,
+.trust-section .section-heading p {
+  color: #101b13;
+}
+
+.trust-section .section-heading p {
+  opacity: 0.72;
+}
+
+.trust-list {
+  display: grid;
+  gap: 18px;
+}
+
+.trust-list article {
+  display: grid;
+  grid-template-columns: minmax(200px, 0.32fr) minmax(0, 1fr);
+  gap: 28px;
+  align-items: baseline;
+  border-top: 1px solid rgba(16, 27, 19, 0.2);
+  padding: 24px 0;
+}
+
+.trust-list span {
+  font-size: 20px;
+  font-weight: 850;
+}
+
+.trust-list p {
+  margin: 0;
+  max-width: 720px;
+  color: rgba(16, 27, 19, 0.72);
+  font-size: 20px;
+  line-height: 1.45;
+}
+
+.sources-section {
+  background: #102218;
+}
+
+.source-steps {
+  display: grid;
+  grid-template-columns: repeat(3, minmax(0, 1fr));
+  gap: 18px;
+}
+
+.source-steps article {
+  min-height: 270px;
+  border: 1px solid rgba(255, 255, 255, 0.16);
+  border-radius: 8px;
+  padding: 26px;
+  background: rgba(255, 255, 255, 0.055);
+}
+
+.step-number {
+  display: block;
+  margin-bottom: 44px;
+  color: rgba(238, 255, 235, 0.5);
+  font-size: 14px;
+  font-weight: 800;
+}
+
+.source-steps h3 {
+  margin: 0;
+  color: #f8fff7;
+  font-size: 26px;
+  line-height: 1.08;
+}
+
+.source-steps p {
+  margin: 18px 0 0;
+  color: rgba(239, 249, 238, 0.68);
+  font-size: 16px;
+  line-height: 1.58;
+}
+
+.final-cta {
+  display: grid;
+  min-height: 52svh;
+  place-items: center;
+  gap: 28px;
+  padding: clamp(72px, 10vw, 128px) clamp(20px, 5vw, 72px);
+  background:
+    linear-gradient(rgba(7, 17, 13, 0.5), rgba(7, 17, 13, 0.86)),
+    url('../../docs/screenshot.png') center / cover;
+  text-align: center;
+}
+
+.final-cta h2 {
+  max-width: 920px;
+  margin: 0;
+  color: #ffffff;
+  font-size: clamp(38px, 6vw, 82px);
+  font-weight: 800;
+  line-height: 0.98;
+  letter-spacing: 0;
+}
+
+.site-footer {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 24px;
+  padding: 28px clamp(20px, 5vw, 72px);
+  background: #07110d;
+  color: rgba(239, 249, 238, 0.62);
+  font-size: 14px;
+}
+
+.site-footer p {
+  margin: 0;
+  max-width: 620px;
+}
+
+.site-footer div {
+  display: flex;
+  flex-wrap: wrap;
+  justify-content: flex-end;
+  gap: 16px;
+}
+
+.site-footer a:hover {
+  color: #ffffff;
+}
+
+@keyframes aerialDrift {
+  from {
+    transform: scale(1.03) translate3d(-0.8%, -0.4%, 0);
+  }
+  to {
+    transform: scale(1.08) translate3d(0.8%, 0.4%, 0);
+  }
+}
+
+@media (prefers-reduced-motion: reduce) {
+  html {
+    scroll-behavior: auto;
+  }
+
+  .hero-image {
+    animation: none;
+  }
+
+  .button {
+    transition: none;
+  }
+}
+
+@media (max-width: 900px) {
+  .site-nav {
+    position: absolute;
+  }
+
+  .site-nav nav {
+    display: none;
+  }
+
+  .hero {
+    min-height: 90svh;
+    padding-top: 112px;
+  }
+
+  .intro-band,
+  .section-heading,
+  .trust-list article {
+    grid-template-columns: 1fr;
+  }
+
+  .feature-grid,
+  .source-steps {
+    grid-template-columns: 1fr;
+  }
+
+  .feature-card,
+  .source-steps article {
+    min-height: auto;
+  }
+
+  .site-footer {
+    align-items: flex-start;
+    flex-direction: column;
+  }
+
+  .site-footer div {
+    justify-content: flex-start;
+  }
+}
+
+@media (max-width: 560px) {
+  .hero {
+    min-height: 86svh;
+    padding-bottom: 54px;
+  }
+
+  .hero-actions {
+    width: 100%;
+  }
+
+  .button {
+    width: 100%;
+    padding-inline: 16px;
+  }
+
+  .intro-band {
+    gap: 14px;
+  }
+
+  .section-heading h2,
+  .final-cta h2 {
+    line-height: 1.04;
+  }
+}

--- a/site/src/site.css
+++ b/site/src/site.css
@@ -80,15 +80,16 @@ a {
 
 .hero {
   position: relative;
-  min-height: 88svh;
+  min-height: 100svh;
   overflow: hidden;
-  display: grid;
-  align-items: end;
-  padding: 128px clamp(20px, 5vw, 72px) 80px;
+  display: flex;
+  align-items: flex-end;
+  padding: 120px clamp(20px, 5vw, 72px) 44px;
   isolation: isolate;
 }
 
-.hero-image {
+.hero-video,
+.hero-poster-fallback {
   position: absolute;
   inset: 0;
   z-index: -3;
@@ -96,8 +97,19 @@ a {
   height: 100%;
   object-fit: cover;
   object-position: center;
-  transform: scale(1.03);
-  animation: aerialDrift 22s ease-in-out infinite alternate;
+}
+
+.hero-video {
+  background: #0a2d49;
+}
+
+.hero-poster-fallback {
+  opacity: 0;
+  transition: opacity 180ms ease;
+}
+
+.video-failed .hero-poster-fallback {
+  opacity: 1;
 }
 
 .hero-shade {
@@ -105,43 +117,292 @@ a {
   inset: 0;
   z-index: -2;
   background:
-    linear-gradient(90deg, rgba(5, 12, 8, 0.82) 0%, rgba(5, 12, 8, 0.48) 38%, rgba(5, 12, 8, 0.08) 72%),
-    linear-gradient(0deg, rgba(7, 17, 13, 0.78) 0%, rgba(7, 17, 13, 0.12) 44%, rgba(7, 17, 13, 0.38) 100%);
+    radial-gradient(circle at 50% 45%, rgba(255, 255, 255, 0.08), rgba(4, 16, 26, 0) 42%),
+    linear-gradient(180deg, rgba(3, 18, 32, 0.16) 0%, rgba(4, 25, 38, 0.08) 48%, rgba(2, 30, 37, 0.56) 100%),
+    linear-gradient(90deg, rgba(2, 20, 34, 0.36), rgba(2, 20, 34, 0) 34%, rgba(2, 20, 34, 0.22));
+}
+
+.macify-scene {
+  position: absolute;
+  inset: 0;
+  z-index: 1;
+  color: rgba(255, 255, 255, 0.9);
+  text-shadow: 0 2px 18px rgba(0, 18, 38, 0.38);
+  pointer-events: none;
+}
+
+.scene-location,
+.scene-weather {
+  position: absolute;
+  top: clamp(92px, 9vw, 128px);
+  display: grid;
+  gap: 4px;
+}
+
+.scene-location {
+  left: clamp(22px, 4vw, 48px);
+}
+
+.scene-location span,
+.scene-weather .weather-temp {
+  color: #ffffff;
+  font-size: clamp(16px, 1.6vw, 24px);
+  font-weight: 800;
+  line-height: 1;
+}
+
+.scene-location small,
+.scene-weather small {
+  color: rgba(255, 255, 255, 0.74);
+  font-size: clamp(12px, 1vw, 16px);
+  font-weight: 600;
+  line-height: 1.2;
+}
+
+.scene-weather {
+  right: clamp(22px, 4vw, 48px);
+  grid-template-columns: auto auto;
+  align-items: center;
+  justify-items: end;
+}
+
+.scene-weather small {
+  grid-column: 1 / -1;
+}
+
+.weather-sun {
+  position: relative;
+  width: 22px;
+  height: 22px;
+  border-radius: 999px;
+  background: #ffd449;
+  box-shadow:
+    0 0 18px rgba(255, 212, 73, 0.72),
+    0 0 0 4px rgba(255, 212, 73, 0.12);
+}
+
+.scene-center {
+  position: absolute;
+  top: 48%;
+  left: 50%;
+  width: min(460px, 54vw);
+  transform: translate(-50%, -50%);
+  display: grid;
+  justify-items: center;
+  gap: clamp(14px, 2vw, 24px);
+  text-align: center;
+}
+
+.sky-arc {
+  width: min(420px, 100%);
+  height: auto;
+  overflow: visible;
+}
+
+.sky-arc text {
+  fill: rgba(255, 255, 255, 0.86);
+  font-size: 14px;
+  font-weight: 700;
+}
+
+.arc-fill {
+  fill: none;
+  stroke: rgba(255, 255, 255, 0.18);
+  stroke-width: 18;
+  stroke-linecap: round;
+}
+
+.arc-line {
+  fill: none;
+  stroke-width: 2.4;
+  stroke-linecap: round;
+}
+
+.arc-line.active {
+  stroke: #ffd447;
+}
+
+.arc-line.soft,
+.arc-axis {
+  stroke: rgba(255, 255, 255, 0.56);
+}
+
+.arc-axis {
+  stroke-dasharray: 4 7;
+  stroke-width: 1;
+}
+
+.arc-axis.vertical {
+  stroke-dasharray: none;
+  opacity: 0.46;
+}
+
+.arc-node {
+  fill: rgba(5, 26, 45, 0.86);
+  stroke: rgba(255, 255, 255, 0.78);
+  stroke-width: 2;
+}
+
+.arc-node.active {
+  fill: #ffd447;
+  stroke: #fff2a7;
+}
+
+.scene-center blockquote {
+  margin: 0;
+}
+
+.scene-center blockquote p {
+  margin: 0;
+  color: rgba(255, 255, 255, 0.94);
+  font-size: clamp(18px, 2vw, 25px);
+  font-style: italic;
+  font-weight: 650;
+  line-height: 1.28;
+}
+
+.scene-center cite {
+  display: block;
+  margin-top: 12px;
+  color: rgba(255, 255, 255, 0.7);
+  font-size: clamp(13px, 1.2vw, 17px);
+  font-style: normal;
+  font-weight: 600;
+}
+
+.scene-center cite::before {
+  content: "";
+  display: inline-block;
+  width: 18px;
+  height: 1px;
+  margin-right: 8px;
+  vertical-align: middle;
+  background: rgba(255, 255, 255, 0.62);
+}
+
+.scene-control,
+.scene-control-stack span {
+  position: relative;
+  display: grid;
+  width: 46px;
+  height: 46px;
+  place-items: center;
+  border: 1px solid rgba(255, 255, 255, 0.16);
+  border-radius: 999px;
+  background: rgba(34, 116, 142, 0.46);
+  box-shadow: 0 14px 30px rgba(0, 24, 40, 0.22);
+  backdrop-filter: blur(12px);
+}
+
+.scene-control.left {
+  position: absolute;
+  left: clamp(24px, 4vw, 48px);
+  bottom: clamp(210px, 24vh, 270px);
+}
+
+.scene-control-stack {
+  position: absolute;
+  right: clamp(24px, 4vw, 48px);
+  bottom: clamp(24px, 4vw, 48px);
+  display: grid;
+  gap: 14px;
+}
+
+.scene-control.left span {
+  position: relative;
+  width: 14px;
+  height: 14px;
+  border: 2px solid rgba(255, 255, 255, 0.9);
+  border-radius: 999px;
+}
+
+.scene-control.left span::before,
+.scene-control.left span::after {
+  position: absolute;
+  content: "";
+  background: rgba(255, 255, 255, 0.9);
+}
+
+.scene-control.left span::before {
+  left: 5px;
+  bottom: -14px;
+  width: 2px;
+  height: 13px;
+}
+
+.scene-control.left span::after {
+  left: -4px;
+  bottom: -11px;
+  width: 22px;
+  height: 2px;
+}
+
+.grid-icon {
+  background-image:
+    radial-gradient(circle, rgba(255, 255, 255, 0.92) 2px, transparent 2.5px),
+    radial-gradient(circle, rgba(255, 255, 255, 0.92) 2px, transparent 2.5px);
+  background-position:
+    15px 15px,
+    25px 25px;
+  background-size: 20px 20px;
+}
+
+.refresh-icon::before {
+  content: "";
+  width: 18px;
+  height: 18px;
+  border: 2px solid rgba(255, 255, 255, 0.92);
+  border-left-color: transparent;
+  border-radius: 999px;
+}
+
+.refresh-icon::after {
+  position: absolute;
+  content: "";
+  width: 7px;
+  height: 7px;
+  margin: -12px 0 0 13px;
+  border-top: 2px solid rgba(255, 255, 255, 0.92);
+  border-right: 2px solid rgba(255, 255, 255, 0.92);
+  transform: rotate(30deg);
 }
 
 .hero-content {
-  width: min(680px, 100%);
+  position: relative;
+  z-index: 2;
+  width: min(560px, 100%);
+  margin-left: clamp(0px, 7vw, 96px);
 }
 
 .availability {
-  margin: 0 0 18px;
-  color: rgba(236, 255, 238, 0.78);
-  font-size: 15px;
+  margin: 0 0 14px;
+  color: rgba(241, 253, 255, 0.78);
+  font-size: 14px;
   font-weight: 700;
 }
 
 .hero h1 {
   margin: 0;
   color: #ffffff;
-  font-size: clamp(64px, 11vw, 146px);
+  font-size: clamp(42px, 5.8vw, 68px);
   font-weight: 800;
-  line-height: 0.9;
+  line-height: 0.98;
   letter-spacing: 0;
 }
 
 .hero-copy {
-  max-width: 620px;
-  margin: 28px 0 0;
-  color: rgba(248, 255, 249, 0.9);
-  font-size: clamp(20px, 2.4vw, 30px);
-  line-height: 1.22;
+  max-width: 540px;
+  margin: 14px 0 0;
+  color: rgba(241, 253, 255, 0.88);
+  font-size: clamp(17px, 1.7vw, 21px);
+  line-height: 1.38;
 }
 
 .hero-actions {
   display: flex;
   flex-wrap: wrap;
   gap: 14px;
-  margin-top: 34px;
+  margin-top: 20px;
 }
 
 .button {
@@ -339,7 +600,7 @@ a {
   padding: clamp(72px, 10vw, 128px) clamp(20px, 5vw, 72px);
   background:
     linear-gradient(rgba(7, 17, 13, 0.5), rgba(7, 17, 13, 0.86)),
-    url('../../docs/screenshot.png') center / cover;
+    url('https://media.macify.candobear.com/hero/palau-jellies-poster.jpg') center / cover;
   text-align: center;
 }
 
@@ -380,22 +641,17 @@ a {
   color: #ffffff;
 }
 
-@keyframes aerialDrift {
-  from {
-    transform: scale(1.03) translate3d(-0.8%, -0.4%, 0);
-  }
-  to {
-    transform: scale(1.08) translate3d(0.8%, 0.4%, 0);
-  }
-}
-
 @media (prefers-reduced-motion: reduce) {
   html {
     scroll-behavior: auto;
   }
 
-  .hero-image {
-    animation: none;
+  .hero-video {
+    display: none;
+  }
+
+  .hero-poster-fallback {
+    opacity: 1;
   }
 
   .button {
@@ -413,8 +669,21 @@ a {
   }
 
   .hero {
-    min-height: 90svh;
+    min-height: 100svh;
     padding-top: 112px;
+  }
+
+  .hero-content {
+    margin-left: 0;
+  }
+
+  .scene-center {
+    width: min(420px, 82vw);
+  }
+
+  .scene-location,
+  .scene-weather {
+    top: 88px;
   }
 
   .intro-band,
@@ -445,8 +714,45 @@ a {
 
 @media (max-width: 560px) {
   .hero {
-    min-height: 86svh;
-    padding-bottom: 54px;
+    padding-bottom: 38px;
+  }
+
+  .scene-center {
+    top: 42%;
+  }
+
+  .sky-arc {
+    width: min(320px, 90vw);
+  }
+
+  .scene-location span,
+  .scene-weather .weather-temp {
+    font-size: 15px;
+  }
+
+  .scene-location small,
+  .scene-weather small {
+    font-size: 11px;
+  }
+
+  .scene-control,
+  .scene-control-stack span {
+    width: 40px;
+    height: 40px;
+  }
+
+  .scene-control.left,
+  .scene-control-stack {
+    bottom: 18px;
+  }
+
+  .scene-control.left,
+  .scene-control-stack {
+    display: none;
+  }
+
+  .hero h1 {
+    font-size: clamp(42px, 14vw, 58px);
   }
 
   .hero-actions {

--- a/site/src/site.css
+++ b/site/src/site.css
@@ -280,105 +280,11 @@ a {
   background: rgba(255, 255, 255, 0.62);
 }
 
-.scene-control,
-.scene-control-stack span {
-  position: relative;
-  display: grid;
-  width: 46px;
-  height: 46px;
-  place-items: center;
-  border: 1px solid rgba(255, 255, 255, 0.16);
-  border-radius: 999px;
-  background: rgba(34, 116, 142, 0.46);
-  box-shadow: 0 14px 30px rgba(0, 24, 40, 0.22);
-  backdrop-filter: blur(12px);
-}
-
-.scene-control.left {
-  position: absolute;
-  left: clamp(24px, 4vw, 48px);
-  bottom: clamp(210px, 24vh, 270px);
-}
-
-.scene-control-stack {
-  position: absolute;
-  right: clamp(24px, 4vw, 48px);
-  bottom: clamp(24px, 4vw, 48px);
-  display: grid;
-  gap: 14px;
-}
-
-.scene-control.left span {
-  position: relative;
-  width: 14px;
-  height: 14px;
-  border: 2px solid rgba(255, 255, 255, 0.9);
-  border-radius: 999px;
-}
-
-.scene-control.left span::before,
-.scene-control.left span::after {
-  position: absolute;
-  content: "";
-  background: rgba(255, 255, 255, 0.9);
-}
-
-.scene-control.left span::before {
-  left: 5px;
-  bottom: -14px;
-  width: 2px;
-  height: 13px;
-}
-
-.scene-control.left span::after {
-  left: -4px;
-  bottom: -11px;
-  width: 22px;
-  height: 2px;
-}
-
-.grid-icon {
-  background-image:
-    radial-gradient(circle, rgba(255, 255, 255, 0.92) 2px, transparent 2.5px),
-    radial-gradient(circle, rgba(255, 255, 255, 0.92) 2px, transparent 2.5px);
-  background-position:
-    15px 15px,
-    25px 25px;
-  background-size: 20px 20px;
-}
-
-.refresh-icon::before {
-  content: "";
-  width: 18px;
-  height: 18px;
-  border: 2px solid rgba(255, 255, 255, 0.92);
-  border-left-color: transparent;
-  border-radius: 999px;
-}
-
-.refresh-icon::after {
-  position: absolute;
-  content: "";
-  width: 7px;
-  height: 7px;
-  margin: -12px 0 0 13px;
-  border-top: 2px solid rgba(255, 255, 255, 0.92);
-  border-right: 2px solid rgba(255, 255, 255, 0.92);
-  transform: rotate(30deg);
-}
-
 .hero-content {
   position: relative;
   z-index: 2;
   width: min(560px, 100%);
   margin-left: clamp(0px, 7vw, 96px);
-}
-
-.availability {
-  margin: 0 0 14px;
-  color: rgba(241, 253, 255, 0.78);
-  font-size: 14px;
-  font-weight: 700;
 }
 
 .hero h1 {
@@ -440,8 +346,10 @@ a {
   grid-template-columns: minmax(0, 1fr) minmax(0, 1fr);
   gap: 24px;
   padding: 28px clamp(20px, 5vw, 72px);
-  background: #e9f3de;
-  color: #142017;
+  background:
+    linear-gradient(90deg, rgba(4, 82, 114, 0.96), rgba(4, 112, 128, 0.94)),
+    #064a64;
+  color: #eaf9ff;
 }
 
 .intro-band p {
@@ -472,6 +380,10 @@ a {
   letter-spacing: 0;
 }
 
+.split-title span {
+  display: block;
+}
+
 .section-heading p {
   margin: 0;
   color: rgba(239, 249, 238, 0.68);
@@ -480,21 +392,23 @@ a {
 }
 
 .features-section {
-  background: #07110d;
+  background:
+    radial-gradient(circle at 16% 0%, rgba(97, 178, 202, 0.2), transparent 34%),
+    linear-gradient(180deg, #07364d 0%, #062f42 58%, #052536 100%);
 }
 
 .feature-grid {
   display: grid;
   grid-template-columns: repeat(3, minmax(0, 1fr));
   gap: 1px;
-  border: 1px solid rgba(255, 255, 255, 0.12);
-  background: rgba(255, 255, 255, 0.12);
+  border: 1px solid rgba(181, 230, 241, 0.18);
+  background: rgba(181, 230, 241, 0.16);
 }
 
 .feature-card {
   min-height: 238px;
   padding: clamp(24px, 3vw, 36px);
-  background: #0b1811;
+  background: rgba(7, 53, 72, 0.82);
 }
 
 .feature-card h3 {
@@ -506,23 +420,26 @@ a {
 
 .feature-card p {
   margin: 20px 0 0;
-  color: rgba(239, 249, 238, 0.68);
+  color: rgba(219, 245, 250, 0.7);
   font-size: 16px;
   line-height: 1.58;
 }
 
 .trust-section {
-  background: #dfeccf;
-  color: #101b13;
+  background:
+    radial-gradient(circle at 82% 4%, rgba(255, 216, 132, 0.14), transparent 28%),
+    linear-gradient(180deg, #0a455c 0%, #08384d 56%, #062b3d 100%);
+  color: #e9f8ff;
 }
 
 .trust-section .section-heading h2,
 .trust-section .section-heading p {
-  color: #101b13;
+  color: #e9f8ff;
 }
 
 .trust-section .section-heading p {
-  opacity: 0.72;
+  color: rgba(219, 245, 250, 0.74);
+  opacity: 1;
 }
 
 .trust-list {
@@ -535,7 +452,7 @@ a {
   grid-template-columns: minmax(200px, 0.32fr) minmax(0, 1fr);
   gap: 28px;
   align-items: baseline;
-  border-top: 1px solid rgba(16, 27, 19, 0.2);
+  border-top: 1px solid rgba(181, 230, 241, 0.2);
   padding: 24px 0;
 }
 
@@ -547,13 +464,15 @@ a {
 .trust-list p {
   margin: 0;
   max-width: 720px;
-  color: rgba(16, 27, 19, 0.72);
+  color: rgba(219, 245, 250, 0.72);
   font-size: 20px;
   line-height: 1.45;
 }
 
 .sources-section {
-  background: #102218;
+  background:
+    radial-gradient(circle at 74% 0%, rgba(116, 199, 215, 0.12), transparent 30%),
+    linear-gradient(180deg, #062b3d 0%, #052434 100%);
 }
 
 .source-steps {
@@ -735,22 +654,6 @@ a {
     font-size: 11px;
   }
 
-  .scene-control,
-  .scene-control-stack span {
-    width: 40px;
-    height: 40px;
-  }
-
-  .scene-control.left,
-  .scene-control-stack {
-    bottom: 18px;
-  }
-
-  .scene-control.left,
-  .scene-control-stack {
-    display: none;
-  }
-
   .hero h1 {
     font-size: clamp(42px, 14vw, 58px);
   }
@@ -770,6 +673,11 @@ a {
 
   .section-heading h2,
   .final-cta h2 {
+    font-size: clamp(28px, 7vw, 36px);
     line-height: 1.04;
+  }
+
+  .split-title span {
+    white-space: nowrap;
   }
 }

--- a/vite.site.config.js
+++ b/vite.site.config.js
@@ -1,0 +1,13 @@
+import { defineConfig } from 'vite';
+import { svelte } from '@sveltejs/vite-plugin-svelte';
+import tailwindcss from '@tailwindcss/vite';
+
+export default defineConfig({
+  root: 'site',
+  publicDir: false,
+  build: {
+    outDir: '../site-dist',
+    emptyOutDir: true,
+  },
+  plugins: [tailwindcss(), svelte()],
+});


### PR DESCRIPTION
## Summary
- Adds the standalone Macify product site under `site/`.
- Upgrades the hero to a full-screen Palau Jellies 4K R2-hosted video with poster fallback.
- Keeps extension build output separate from the site build and documents the R2 media asset setup.

## Validation
- `npm run build:site`
- `VITE_MACIFY_BASE=https://macify.candobear.com npm run build`
- Verified R2 video URL returns 200 with the expected 996,549,777 byte size.
- Verified R2 Range request returns 206.
- Verified desktop and mobile hero rendering in browser with no console errors.
- Deployed to Cloudflare Pages and verified `https://macify.candobear.com/`.

## Deployment
- Pages project: `macify-candobear-com`
- Site domain: `macify.candobear.com`
- R2 bucket: `macify-candobear-com-assets`
- Media domain: `media.macify.candobear.com`